### PR TITLE
fix spark version in gdmix image and python module dependency 

### DIFF
--- a/gdmix-trainer/setup.py
+++ b/gdmix-trainer/setup.py
@@ -1,13 +1,11 @@
-# Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
-# See LICENSE in the project root for license information.
+from pathlib import Path
 from setuptools import find_namespace_packages, setup
 from sys import platform as _platform
 from sys import version_info as _py_version
-from os import path
 
 
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+current_dir = Path(__file__).resolve().parent
+with open(current_dir.joinpath('README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 if _py_version < (3, 3):
@@ -27,7 +25,7 @@ setup(
                  "Intended Audience :: Developers",
                  "License :: OSI Approved"],
     license='BSD-2-CLAUSE',
-    version='0.2.0',
+    version='0.2.1',
     package_dir={'': 'src'},
     packages=find_namespace_packages(where='src'),
     include_package_data=True,
@@ -44,5 +42,5 @@ setup(
         "dataclasses==0.7",
         "smart-arg==0.2.12"
     ],
-    tests_require=['pytest'],
+    tests_require=['pytest']
 )

--- a/gdmix-trainer/setup.py
+++ b/gdmix-trainer/setup.py
@@ -3,7 +3,10 @@ from setuptools import find_namespace_packages, setup
 from sys import platform as _platform
 from sys import version_info as _py_version
 
+import sys
 
+
+VERSION="0.2.1"
 current_dir = Path(__file__).resolve().parent
 with open(current_dir.joinpath('README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -25,7 +28,7 @@ setup(
                  "Intended Audience :: Developers",
                  "License :: OSI Approved"],
     license='BSD-2-CLAUSE',
-    version='0.2.1',
+    version=f'{VERSION}',
     package_dir={'': 'src'},
     packages=find_namespace_packages(where='src'),
     include_package_data=True,

--- a/gdmix-workflow/images/gdmix/Dockerfile
+++ b/gdmix-workflow/images/gdmix/Dockerfile
@@ -35,14 +35,14 @@ RUN rm -rf /usr/bin/python && \
 RUN sed -i 's/python/python2/g' /usr/bin/yum
 RUN sed -i 's/python/python2/g' /usr/libexec/urlgrabber-ext-down
 
-# Install spark 2.4.6 and its dependencies
+# Install spark 2.4.7 and its dependencies
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     mkdir -p /opt/spark && \
     touch /opt/spark/RELEASE && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
     chgrp root /etc/passwd && chmod ug+rw /etc/passwd
 
-ARG spark_version=2.4.6
+ARG spark_version=2.4.7
 ARG spark_pkg=spark-${spark_version}-bin-hadoop2.7
 ARG img_path=kubernetes/dockerfiles
 ARG k8s_tests=kubernetes/tests

--- a/gdmix-workflow/setup.py
+++ b/gdmix-workflow/setup.py
@@ -1,11 +1,11 @@
-from os import path
+from pathlib import Path
 from setuptools import find_namespace_packages, setup
 from sys import platform as _platform
 from sys import version_info as _py_version
 
 
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+current_dir = Path(__file__).resolve().parent
+with open(current_dir.joinpath('README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 if _py_version < (3, 3):
@@ -25,18 +25,16 @@ setup(
                  "Intended Audience :: Developers",
                  "License :: OSI Approved"],
     license='BSD-2-CLAUSE',
-    version='0.2.0',
+    version='0.2.1',
     package_dir={'': 'src'},
     packages=find_namespace_packages(where='src'),
     package_data={'': ['*.yaml']},
     include_package_data=True,
     install_requires=[
         "setuptools>=41.0.0",
-        # "gdmix-trainer==0.2.0",
+        "gdmix-trainer==0.2.1",
         "google-auth==1.21.1",
         "kfp==0.2.5"
     ],
-    tests_require=[
-        'pytest',
-    ]
+    tests_require=['pytest']
 )

--- a/gdmix-workflow/setup.py
+++ b/gdmix-workflow/setup.py
@@ -3,7 +3,10 @@ from setuptools import find_namespace_packages, setup
 from sys import platform as _platform
 from sys import version_info as _py_version
 
+import sys
 
+
+VERSION="0.2.1"
 current_dir = Path(__file__).resolve().parent
 with open(current_dir.joinpath('README.md'), encoding='utf-8') as f:
     long_description = f.read()
@@ -25,14 +28,14 @@ setup(
                  "Intended Audience :: Developers",
                  "License :: OSI Approved"],
     license='BSD-2-CLAUSE',
-    version='0.2.1',
+    version=f'{VERSION}',
     package_dir={'': 'src'},
     packages=find_namespace_packages(where='src'),
     package_data={'': ['*.yaml']},
     include_package_data=True,
     install_requires=[
         "setuptools>=41.0.0",
-        "gdmix-trainer==0.2.1",
+        f"gdmix-trainer=={VERSION}",
         "google-auth==1.21.1",
         "kfp==0.2.5"
     ],


### PR DESCRIPTION
- fix latest available spark 2 version in gdmix image Dockerfile
- The python wheel was published with wrong dependency, PyPi doesn't allow to overwrite old version, has to release a new version of 0.2.1